### PR TITLE
Polygonomatic: Fix MATIC to match the token list schema

### DIFF
--- a/chains/1.json
+++ b/chains/1.json
@@ -36,7 +36,7 @@
   },
   {
     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-    "name": "Polygon (MATIC)",
+    "name": "Polygon MATIC",
     "symbol": "MATIC",
     "decimals": 18,
     "logoURI": "../images/matic.png"


### PR DESCRIPTION
I don't understand why CI isn't catching the name issue, but it's biting us in https://github.com/tallycash/extension/